### PR TITLE
#402 Swallow InterruptedException caused by closing cluster cache

### DIFF
--- a/ohara-agent/src/main/scala/com/island/ohara/agent/ssh/Cache.scala
+++ b/ohara-agent/src/main/scala/com/island/ohara/agent/ssh/Cache.scala
@@ -146,8 +146,7 @@ object Cache {
             lastUpdate = CommonUtil.current()
           } catch {
             case e: InterruptedException =>
-              // we are closing this thread
-              throw e
+              LOG.info("we are closing this thread")
             case e: Throwable =>
               LOG.error("failed to update cache", e)
           } finally {


### PR DESCRIPTION
required by #402