### PR TITLE
#928 [docs] typo on user_guide

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -37,7 +37,7 @@ docker run --rm -p 12345:12345 oharastream/configurator:0.4-SNAPSHOT --port 1234
 And then you can also create a manager to provide a beautiful UI based on above configurator.
 
 ```bash
-docker run --rm -p 5050:5050 oharastream/manager:0.4-SNAPSHOT --port 5050 --configurator http://$ip:12345/0
+docker run --rm -p 5050:5050 oharastream/manager:0.4-SNAPSHOT --port 5050 --configurator http://$ip:12345/v0
 ```
 
 > Please replace the **ip** by your host's address


### PR DESCRIPTION
```
docker run --rm -p 5050:5050 oharastream/manager:0.4-SNAPSHOT --port 5050 --configurator http://$ip:12345/0
```
-> this command is missing a letter.
```
docker run --rm -p 5050:5050 oharastream/manager:0.4-SNAPSHOT --port 5050 --configurator http://$ip:12345/v0
```

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/oharastream/ohara/blob/master/CONTRIBUTING.md)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#authors))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #928)
- [ ] Add unit tests (or please explain why this PR is not worth having new tests)
just fix typo...
- [x] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)