### PR TITLE
#2245 Stream APIs take multiples from/to topics but the streamapp tak… (backport to 0.7)

### DIFF
--- a/docs/src/rest/rest-stream.rst
+++ b/docs/src/rest/rest-stream.rst
@@ -109,7 +109,13 @@ Example Request
 
   #. jmxPort (**int**) — expose port for jmx ; default is random port
   #. from (**array(string)**) — source topic ; default is empty array
+      .. note::
+       we only support one topic for current version. We will throw exception in start api if you assign
+       more than 1 topic.
   #. to (**array(string)**) — target topic ; default is empty array
+      .. note::
+       we only support one topic for current version. We will throw exception in start api if you assign
+       more than 1 topic.
   #. instances (**int**) — number of running streamApp ; default is 1
 
      The above fields are pre-defined and could use in request body for convenient. The option fields will have no default value,
@@ -462,7 +468,13 @@ Example Request
 
   #. jmxPort (**int**) — expose port for jmx.
   #. from (**array(string)**) — source topic.
+      .. note::
+       we only support one topic for current version. We will throw exception in start api if you assign
+       more than 1 topic.
   #. to (**array(string)**) — target topic.
+      .. note::
+       we only support one topic for current version. We will throw exception in start api if you assign
+       more than 1 topic.
   #. instances (**int**) — number of running streamApp.
 
   .. code-block:: json

--- a/ohara-configurator/src/main/scala/com/island/ohara/configurator/route/StreamRoute.scala
+++ b/ohara-configurator/src/main/scala/com/island/ohara/configurator/route/StreamRoute.scala
@@ -153,6 +153,14 @@ private[configurator] object StreamRoute {
     CommonUtils.requireNonEmpty(data.name, () => "name fail assert")
     CommonUtils.requireConnectionPort(data.jmxPort)
     Objects.requireNonNull(data.jarKey)
+
+    // check the from/to topic size equals one
+    // TODO: this is a workaround to avoid input multiple topics
+    // TODO: please refactor this after the single from/to topic issue resolved...by Sam
+    if (data.from.size > 1 || data.to.size > 1)
+      throw new IllegalArgumentException(
+        s"We don't allow multiple topics of from/to field, actual: from[${data.from}], to[${data.to}]")
+
     // from topic should be defined and starting
     val fromTopics = CommonUtils.requireNonEmpty(data.from.asJava, () => "from topic fail assert")
     if (!topicInfos.exists(t => fromTopics.contains(t.name)))


### PR DESCRIPTION
…e them as single from/to topic (backport to 0.7)

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/oharastream/ohara/blob/master/CONTRIBUTING.md)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#authors))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #2245)
- [x] Add unit tests (or please explain why this PR is not worth having new tests)
- [ ] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)