### PR TITLE
#3150 Added K8S namespace argument for K8SClient and configurator service

### DIFF
--- a/docs/src/user_guide.rst
+++ b/docs/src/user_guide.rst
@@ -840,6 +840,9 @@ How to use Kubernetes in Ohara?
    configurator container /etc/hosts file. If you have DNS server, you
    can just ignore parameter of add-host.
 
+   ``--k8s-namespace``: If you don't use the Kubernetes default namespace,
+   you can assign the --k8s-namespace argument to set other the Kubernetes namespace.
+
    ``--k8s``: Assignment your K8S API server HTTP URL
 
 -  Use Ohara configurator to create a zookeeper and broker in Kubernetes

--- a/docs/src/user_guide.rst
+++ b/docs/src/user_guide.rst
@@ -842,6 +842,7 @@ How to use Kubernetes in Ohara?
 
    ``--k8s-namespace``: If you don't use the Kubernetes default namespace,
    you can assign the --k8s-namespace argument to set other the Kubernetes namespace.
+   Kubernetes namespace default value is "default" string
 
    ``--k8s``: Assignment your K8S API server HTTP URL
 

--- a/ohara-agent/src/main/scala/com/island/ohara/agent/k8s/K8SClient.scala
+++ b/ohara-agent/src/main/scala/com/island/ohara/agent/k8s/K8SClient.scala
@@ -56,7 +56,10 @@ object K8SClient {
 
   private[agent] val K8S_KIND_NAME = "K8S"
 
-  def apply(k8sApiServerURL: String, namespace: String): K8SClient = {
+  def apply(k8sApiServerURL: String): K8SClient = apply(k8sApiServerURL, None)
+
+  def apply(k8sApiServerURL: String, namespaceOption: Option[String]): K8SClient = {
+    val namespace = namespaceOption.getOrElse("default")
     if (k8sApiServerURL.isEmpty) throw new IllegalArgumentException(s"invalid kubernetes api:$k8sApiServerURL")
 
     new K8SClient() with SprayJsonSupport {

--- a/ohara-agent/src/main/scala/com/island/ohara/agent/k8s/K8SClient.scala
+++ b/ohara-agent/src/main/scala/com/island/ohara/agent/k8s/K8SClient.scala
@@ -52,14 +52,14 @@ trait K8SClient {
 
 object K8SClient {
   import scala.concurrent.duration._
-  val TIMEOUT: FiniteDuration = 30 seconds
+  val NAMESPACE_DEFAULT_VALUE: String = "default"
 
+  private[this] val TIMEOUT: FiniteDuration = 30 seconds
   private[agent] val K8S_KIND_NAME = "K8S"
 
-  def apply(k8sApiServerURL: String): K8SClient = apply(k8sApiServerURL, None)
+  def apply(k8sApiServerURL: String): K8SClient = apply(k8sApiServerURL, NAMESPACE_DEFAULT_VALUE)
 
-  def apply(k8sApiServerURL: String, namespaceOption: Option[String]): K8SClient = {
-    val namespace = namespaceOption.getOrElse("default")
+  def apply(k8sApiServerURL: String, namespace: String): K8SClient = {
     if (k8sApiServerURL.isEmpty) throw new IllegalArgumentException(s"invalid kubernetes api:$k8sApiServerURL")
 
     new K8SClient() with SprayJsonSupport {

--- a/ohara-agent/src/main/scala/com/island/ohara/agent/k8s/K8SClient.scala
+++ b/ohara-agent/src/main/scala/com/island/ohara/agent/k8s/K8SClient.scala
@@ -56,13 +56,13 @@ object K8SClient {
 
   private[agent] val K8S_KIND_NAME = "K8S"
 
-  def apply(k8sApiServerURL: String): K8SClient = {
+  def apply(k8sApiServerURL: String, namespace: String): K8SClient = {
     if (k8sApiServerURL.isEmpty) throw new IllegalArgumentException(s"invalid kubernetes api:$k8sApiServerURL")
 
     new K8SClient() with SprayJsonSupport {
       override def containers()(implicit executionContext: ExecutionContext): Future[Seq[ContainerInfo]] =
         HttpExecutor.SINGLETON
-          .get[PodList, K8SErrorResponse](s"$k8sApiServerURL/namespaces/default/pods")
+          .get[PodList, K8SErrorResponse](s"$k8sApiServerURL/namespaces/$namespace/pods")
           .map(podList =>
             podList.items.map(pod => {
               val spec: PodSpec = pod.spec.getOrElse(
@@ -122,7 +122,7 @@ object K8SClient {
                                 configs,
                                 Metadata(uid = None, name = name, labels = None, creationTimestamp = None))
         HttpExecutor.SINGLETON
-          .post[ConfigMap, ConfigMap, K8SErrorResponse](s"$k8sApiServerURL/namespaces/default/configmaps", request)
+          .post[ConfigMap, ConfigMap, K8SErrorResponse](s"$k8sApiServerURL/namespaces/$namespace/configmaps", request)
           .map(_.metadata.name)
       }
 
@@ -133,7 +133,7 @@ object K8SClient {
 
       private[this] def removeConfig(name: String, isForce: Boolean)(
         implicit executionContext: ExecutionContext): Future[Boolean] = {
-        var url = s"$k8sApiServerURL/namespaces/default/configmaps/$name"
+        var url = s"$k8sApiServerURL/namespaces/$namespace/configmaps/$name"
         if (isForce) url += "?gracePeriodSeconds=0"
         HttpExecutor.SINGLETON.delete[K8SErrorResponse](url).map(_ => true)
       }
@@ -141,7 +141,7 @@ object K8SClient {
       override def inspectConfig(name: String)(
         implicit executionContext: ExecutionContext): Future[Map[String, String]] = {
         HttpExecutor.SINGLETON
-          .get[ConfigMap, K8SErrorResponse](s"$k8sApiServerURL/namespaces/default/configmaps/$name")
+          .get[ConfigMap, K8SErrorResponse](s"$k8sApiServerURL/namespaces/$namespace/configmaps/$name")
           .map(_.data)
       }
 
@@ -181,7 +181,7 @@ object K8SClient {
 
       override def log(name: String)(implicit executionContext: ExecutionContext): Future[String] =
         HttpExecutor.SINGLETON
-          .getOnlyMessage(s"$k8sApiServerURL/namespaces/default/pods/$name/log")
+          .getOnlyMessage(s"$k8sApiServerURL/namespaces/$namespace/pods/$name/log")
           .map(msg => if (msg.contains("ERROR:")) throw new IllegalArgumentException(msg) else msg)
 
       override def nodeNameIPInfo()(implicit executionContext: ExecutionContext): Future[Seq[HostAliases]] =
@@ -320,7 +320,7 @@ object K8SClient {
               }
               .flatMap(podSpec => { //name is pod name
                 val request = Pod(Metadata(None, name, Some(Label(labelName)), None), Some(podSpec), None)
-                HttpExecutor.SINGLETON.post[Pod, Pod, K8SErrorResponse](s"$k8sApiServerURL/namespaces/default/pods",
+                HttpExecutor.SINGLETON.post[Pod, Pod, K8SErrorResponse](s"$k8sApiServerURL/namespaces/$namespace/pods",
                                                                         request)
               })
               .map(pod => {
@@ -352,10 +352,10 @@ object K8SClient {
           .flatMap(container => {
             if (isForce)
               HttpExecutor.SINGLETON.delete[K8SErrorResponse](
-                s"$k8sApiServerURL/namespaces/default/pods/${container.name}?gracePeriodSeconds=0")
+                s"$k8sApiServerURL/namespaces/$namespace/pods/${container.name}?gracePeriodSeconds=0")
             else
               HttpExecutor.SINGLETON
-                .delete[K8SErrorResponse](s"$k8sApiServerURL/namespaces/default/pods/${container.name}")
+                .delete[K8SErrorResponse](s"$k8sApiServerURL/namespaces/$namespace/pods/${container.name}")
 
             Future.successful(container)
           })

--- a/ohara-agent/src/test/scala/com/island/ohara/agent/k8s/TestK8SClient.scala
+++ b/ohara-agent/src/test/scala/com/island/ohara/agent/k8s/TestK8SClient.scala
@@ -35,6 +35,7 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 class TestK8SClient extends OharaTest with Matchers {
+  private[this] val namespace: String = "default"
 
   @Test
   def testCreatorEnumator(): Unit = {
@@ -53,7 +54,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.IFNOTPRESENT)
     try {
-      val client = K8SClient(s.url)
+      val client = K8SClient(s.url, namespace)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -80,7 +81,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.IFNOTPRESENT)
     try {
-      val client = K8SClient(s.url)
+      val client = K8SClient(s.url, namespace)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -106,7 +107,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.ALWAYS)
     try {
-      val client = K8SClient(s.url)
+      val client = K8SClient(s.url, namespace)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -132,7 +133,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.NEVER)
     try {
-      val client = K8SClient(s.url)
+      val client = K8SClient(s.url, namespace)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -158,7 +159,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.IFNOTPRESENT)
     try {
-      val client = K8SClient(s.url)
+      val client = K8SClient(s.url, namespace)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -214,7 +215,7 @@ class TestK8SClient extends OharaTest with Matchers {
       }
     }
     try {
-      val client = K8SClient(s.url)
+      val client = K8SClient(s.url, namespace)
       val imagesFromServer = Await.result(client.images(node), 30 seconds)
       imagesFromServer shouldBe images
     } finally s.close()
@@ -223,7 +224,7 @@ class TestK8SClient extends OharaTest with Matchers {
   @Test
   def testForceRemovePod(): Unit = {
     val s = forceRemovePodURL("k8soccl-057aac6a97-bk-c720992")
-    val k8sClient = K8SClient(s.url)
+    val k8sClient = K8SClient(s.url, namespace)
     try {
       val result: ContainerInfo = Await.result(k8sClient.forceRemove("k8soccl-057aac6a97-bk-c720992"), 30 seconds)
       result.name shouldBe "k8soccl-057aac6a97-bk-c720992"
@@ -237,7 +238,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "broker-pod"
     val s = log(podName)
     try {
-      val k8sClient = K8SClient(s.url)
+      val k8sClient = K8SClient(s.url, namespace)
       val result: String = Await.result(k8sClient.log(podName), 5 seconds)
       result shouldBe "start pods ......."
     } finally s.close()
@@ -247,7 +248,7 @@ class TestK8SClient extends OharaTest with Matchers {
   def testCreatePodFailed(): Unit = {
     val s = createFailedPod()
     try {
-      val k8sClient = K8SClient(s.url)
+      val k8sClient = K8SClient(s.url, namespace)
       intercept[IllegalArgumentException] {
         Await.result(
           k8sClient
@@ -270,7 +271,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configMap1"
     val s = configMap(configName)
     try {
-      val k8sClient = K8SClient(s.url)
+      val k8sClient = K8SClient(s.url, namespace)
       val result: Map[String, String] = Await.result(k8sClient.inspectConfig(configName), 5 seconds)
       result.size shouldBe 3
       (1 to 3).foreach(i => result(s"key${i}") shouldBe s"value${i}")
@@ -282,7 +283,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configmap3"
     val s = configMapFailed(configName)
     try {
-      val k8sClient = K8SClient(s.url)
+      val k8sClient = K8SClient(s.url, namespace)
       intercept[IllegalArgumentException] {
         Await.result(k8sClient.inspectConfig(configName), 5 seconds)
       }.getMessage() shouldBe s"configmaps ${configName} not found"
@@ -294,7 +295,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configMap2"
     val s = addConfig(configName)
     try {
-      val k8sClient = K8SClient(s.url)
+      val k8sClient = K8SClient(s.url, namespace)
       val result: String =
         Await.result(k8sClient.addConfig(configName, Map("key4" -> "value4", "key5" -> "value5")), 5 seconds)
       result shouldBe configName
@@ -306,7 +307,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configmap1"
     val s = deleteConfig(configName)
     try {
-      val k8sClient = K8SClient(s.url)
+      val k8sClient = K8SClient(s.url, namespace)
       val result: Boolean = Await.result(k8sClient.removeConfig(configName), 5 seconds)
       result shouldBe true
     } finally s.close()

--- a/ohara-agent/src/test/scala/com/island/ohara/agent/k8s/TestK8SClient.scala
+++ b/ohara-agent/src/test/scala/com/island/ohara/agent/k8s/TestK8SClient.scala
@@ -35,8 +35,8 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 class TestK8SClient extends OharaTest with Matchers {
-  private[this] val namespace: String = "default"
-
+  private[this] val namespaceOption = Option("default")
+  private[this] val namespace = namespaceOption.get
   @Test
   def testCreatorEnumator(): Unit = {
     ImagePullPolicy.ALWAYS.toString shouldBe "Always"
@@ -54,7 +54,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.IFNOTPRESENT)
     try {
-      val client = K8SClient(s.url, namespace)
+      val client = K8SClient(s.url, namespaceOption)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -81,7 +81,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.IFNOTPRESENT)
     try {
-      val client = K8SClient(s.url, namespace)
+      val client = K8SClient(s.url, namespaceOption)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -107,7 +107,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.ALWAYS)
     try {
-      val client = K8SClient(s.url, namespace)
+      val client = K8SClient(s.url, namespaceOption)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -133,7 +133,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.NEVER)
     try {
-      val client = K8SClient(s.url, namespace)
+      val client = K8SClient(s.url, namespaceOption)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -159,7 +159,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.IFNOTPRESENT)
     try {
-      val client = K8SClient(s.url, namespace)
+      val client = K8SClient(s.url, namespaceOption)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -215,7 +215,7 @@ class TestK8SClient extends OharaTest with Matchers {
       }
     }
     try {
-      val client = K8SClient(s.url, namespace)
+      val client = K8SClient(s.url, namespaceOption)
       val imagesFromServer = Await.result(client.images(node), 30 seconds)
       imagesFromServer shouldBe images
     } finally s.close()
@@ -224,7 +224,7 @@ class TestK8SClient extends OharaTest with Matchers {
   @Test
   def testForceRemovePod(): Unit = {
     val s = forceRemovePodURL("k8soccl-057aac6a97-bk-c720992")
-    val k8sClient = K8SClient(s.url, namespace)
+    val k8sClient = K8SClient(s.url, namespaceOption)
     try {
       val result: ContainerInfo = Await.result(k8sClient.forceRemove("k8soccl-057aac6a97-bk-c720992"), 30 seconds)
       result.name shouldBe "k8soccl-057aac6a97-bk-c720992"
@@ -238,7 +238,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "broker-pod"
     val s = log(podName)
     try {
-      val k8sClient = K8SClient(s.url, namespace)
+      val k8sClient = K8SClient(s.url, namespaceOption)
       val result: String = Await.result(k8sClient.log(podName), 5 seconds)
       result shouldBe "start pods ......."
     } finally s.close()
@@ -248,7 +248,7 @@ class TestK8SClient extends OharaTest with Matchers {
   def testCreatePodFailed(): Unit = {
     val s = createFailedPod()
     try {
-      val k8sClient = K8SClient(s.url, namespace)
+      val k8sClient = K8SClient(s.url, namespaceOption)
       intercept[IllegalArgumentException] {
         Await.result(
           k8sClient
@@ -271,7 +271,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configMap1"
     val s = configMap(configName)
     try {
-      val k8sClient = K8SClient(s.url, namespace)
+      val k8sClient = K8SClient(s.url, namespaceOption)
       val result: Map[String, String] = Await.result(k8sClient.inspectConfig(configName), 5 seconds)
       result.size shouldBe 3
       (1 to 3).foreach(i => result(s"key${i}") shouldBe s"value${i}")
@@ -283,7 +283,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configmap3"
     val s = configMapFailed(configName)
     try {
-      val k8sClient = K8SClient(s.url, namespace)
+      val k8sClient = K8SClient(s.url, namespaceOption)
       intercept[IllegalArgumentException] {
         Await.result(k8sClient.inspectConfig(configName), 5 seconds)
       }.getMessage() shouldBe s"configmaps ${configName} not found"
@@ -295,7 +295,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configMap2"
     val s = addConfig(configName)
     try {
-      val k8sClient = K8SClient(s.url, namespace)
+      val k8sClient = K8SClient(s.url, namespaceOption)
       val result: String =
         Await.result(k8sClient.addConfig(configName, Map("key4" -> "value4", "key5" -> "value5")), 5 seconds)
       result shouldBe configName
@@ -307,7 +307,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configmap1"
     val s = deleteConfig(configName)
     try {
-      val k8sClient = K8SClient(s.url, namespace)
+      val k8sClient = K8SClient(s.url, namespaceOption)
       val result: Boolean = Await.result(k8sClient.removeConfig(configName), 5 seconds)
       result shouldBe true
     } finally s.close()

--- a/ohara-agent/src/test/scala/com/island/ohara/agent/k8s/TestK8SClient.scala
+++ b/ohara-agent/src/test/scala/com/island/ohara/agent/k8s/TestK8SClient.scala
@@ -35,8 +35,8 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 class TestK8SClient extends OharaTest with Matchers {
-  private[this] val namespaceOption = Option("default")
-  private[this] val namespace = namespaceOption.get
+  private[this] val namespace: String = K8SClient.NAMESPACE_DEFAULT_VALUE
+
   @Test
   def testCreatorEnumator(): Unit = {
     ImagePullPolicy.ALWAYS.toString shouldBe "Always"
@@ -54,7 +54,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.IFNOTPRESENT)
     try {
-      val client = K8SClient(s.url, namespaceOption)
+      val client = K8SClient(s.url)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -81,7 +81,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.IFNOTPRESENT)
     try {
-      val client = K8SClient(s.url, namespaceOption)
+      val client = K8SClient(s.url)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -107,7 +107,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.ALWAYS)
     try {
-      val client = K8SClient(s.url, namespaceOption)
+      val client = K8SClient(s.url)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -133,7 +133,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.NEVER)
     try {
-      val client = K8SClient(s.url, namespaceOption)
+      val client = K8SClient(s.url)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -159,7 +159,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "container1"
     val s = imagePolicyURL(nodeName, podName, ImagePullPolicy.IFNOTPRESENT)
     try {
-      val client = K8SClient(s.url, namespaceOption)
+      val client = K8SClient(s.url)
       val result: Option[ContainerInfo] = Await.result(
         client
           .containerCreator()
@@ -215,7 +215,7 @@ class TestK8SClient extends OharaTest with Matchers {
       }
     }
     try {
-      val client = K8SClient(s.url, namespaceOption)
+      val client = K8SClient(s.url)
       val imagesFromServer = Await.result(client.images(node), 30 seconds)
       imagesFromServer shouldBe images
     } finally s.close()
@@ -224,7 +224,7 @@ class TestK8SClient extends OharaTest with Matchers {
   @Test
   def testForceRemovePod(): Unit = {
     val s = forceRemovePodURL("k8soccl-057aac6a97-bk-c720992")
-    val k8sClient = K8SClient(s.url, namespaceOption)
+    val k8sClient = K8SClient(s.url)
     try {
       val result: ContainerInfo = Await.result(k8sClient.forceRemove("k8soccl-057aac6a97-bk-c720992"), 30 seconds)
       result.name shouldBe "k8soccl-057aac6a97-bk-c720992"
@@ -238,7 +238,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val podName = "broker-pod"
     val s = log(podName)
     try {
-      val k8sClient = K8SClient(s.url, namespaceOption)
+      val k8sClient = K8SClient(s.url)
       val result: String = Await.result(k8sClient.log(podName), 5 seconds)
       result shouldBe "start pods ......."
     } finally s.close()
@@ -248,7 +248,7 @@ class TestK8SClient extends OharaTest with Matchers {
   def testCreatePodFailed(): Unit = {
     val s = createFailedPod()
     try {
-      val k8sClient = K8SClient(s.url, namespaceOption)
+      val k8sClient = K8SClient(s.url)
       intercept[IllegalArgumentException] {
         Await.result(
           k8sClient
@@ -271,7 +271,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configMap1"
     val s = configMap(configName)
     try {
-      val k8sClient = K8SClient(s.url, namespaceOption)
+      val k8sClient = K8SClient(s.url)
       val result: Map[String, String] = Await.result(k8sClient.inspectConfig(configName), 5 seconds)
       result.size shouldBe 3
       (1 to 3).foreach(i => result(s"key${i}") shouldBe s"value${i}")
@@ -283,7 +283,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configmap3"
     val s = configMapFailed(configName)
     try {
-      val k8sClient = K8SClient(s.url, namespaceOption)
+      val k8sClient = K8SClient(s.url)
       intercept[IllegalArgumentException] {
         Await.result(k8sClient.inspectConfig(configName), 5 seconds)
       }.getMessage() shouldBe s"configmaps ${configName} not found"
@@ -295,7 +295,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configMap2"
     val s = addConfig(configName)
     try {
-      val k8sClient = K8SClient(s.url, namespaceOption)
+      val k8sClient = K8SClient(s.url)
       val result: String =
         Await.result(k8sClient.addConfig(configName, Map("key4" -> "value4", "key5" -> "value5")), 5 seconds)
       result shouldBe configName
@@ -307,7 +307,7 @@ class TestK8SClient extends OharaTest with Matchers {
     val configName = "configmap1"
     val s = deleteConfig(configName)
     try {
-      val k8sClient = K8SClient(s.url, namespaceOption)
+      val k8sClient = K8SClient(s.url)
       val result: Boolean = Await.result(k8sClient.removeConfig(configName), 5 seconds)
       result shouldBe true
     } finally s.close()

--- a/ohara-agent/src/test/scala/com/island/ohara/agent/k8s/TestK8SClient.scala
+++ b/ohara-agent/src/test/scala/com/island/ohara/agent/k8s/TestK8SClient.scala
@@ -331,7 +331,7 @@ class TestK8SClient extends OharaTest with Matchers {
        """.stripMargin
 
     toServer {
-      path("namespaces" / "default" / "configmaps" / configName) {
+      path("namespaces" / namespace / "configmaps" / configName) {
         delete {
           complete(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, response)))
         }
@@ -346,8 +346,8 @@ class TestK8SClient extends OharaTest with Matchers {
                        |  "apiVersion": "v1",
                        |  "metadata": {
                        |    "name": "${configName}",
-                       |    "namespace": "default",
-                       |    "selfLink": "/api/v1/namespaces/default/configmaps/configmap2",
+                       |    "namespace": "$namespace",
+                       |    "selfLink": "/api/v1/namespaces/$namespace/configmaps/configmap2",
                        |    "uid": "8ee6258d-efb9-11e9-8f70-8ae0e3c47d1e",
                        |    "resourceVersion": "5134262",
                        |    "creationTimestamp": "2019-10-16T02:06:25Z"
@@ -360,7 +360,7 @@ class TestK8SClient extends OharaTest with Matchers {
        """.stripMargin
 
     toServer {
-      path("namespaces" / "default" / "configmaps") {
+      path("namespaces" / namespace / "configmaps") {
         post {
           entity(as[ConfigMap]) { requestConfigMap =>
             {
@@ -394,7 +394,7 @@ class TestK8SClient extends OharaTest with Matchers {
                       |}
        """.stripMargin
     toServer {
-      path("namespaces" / "default" / "configmaps" / configMapName) {
+      path("namespaces" / namespace / "configmaps" / configMapName) {
         get {
           complete(
             HttpResponse(status = StatusCodes.BadRequest,
@@ -411,13 +411,13 @@ class TestK8SClient extends OharaTest with Matchers {
                       |  "apiVersion": "v1",
                       |  "metadata": {
                       |    "name": "${configMapName}",
-                      |    "namespace": "default",
-                      |    "selfLink": "/api/v1/namespaces/default/configmaps/myconfigyaml",
+                      |    "namespace": "$namespace",
+                      |    "selfLink": "/api/v1/namespaces/$namespace/configmaps/myconfigyaml",
                       |    "uid": "21afbca4-ef22-11e9-8f70-8ae0e3c47d1e",
                       |    "resourceVersion": "5035864",
                       |    "creationTimestamp": "2019-10-15T08:02:28Z",
                       |    "annotations": {
-                      |      "kubectl.kubernetes.io/last-applied-configuration": {\"apiVersion\":\"v1\",\"data\":{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"name\":\"myconfigyaml\",\"namespace\":\"default\"}}
+                      |      "kubectl.kubernetes.io/last-applied-configuration": {\"apiVersion\":\"v1\",\"data\":{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"name\":\"myconfigyaml\",\"namespace\":\"$namespace\"}}
                       |    }
                       |  },
                       |  "data": {
@@ -434,7 +434,7 @@ class TestK8SClient extends OharaTest with Matchers {
     configMap.metadata.name shouldBe configMapName
 
     toServer {
-      path("namespaces" / "default" / "configmaps" / configMapName) {
+      path("namespaces" / namespace / "configmaps" / configMapName) {
         get {
           complete(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, response)))
         }
@@ -512,7 +512,7 @@ class TestK8SClient extends OharaTest with Matchers {
           complete(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, nodesResponse)))
         }
       } ~
-        path("namespaces" / "default" / "pods") {
+        path("namespaces" / namespace / "pods") {
           post {
             entity(as[Pod]) { createPod =>
               createPod.spec.get.containers.head.imagePullPolicy shouldBe Some(expectImagePullPolicy)
@@ -526,7 +526,7 @@ class TestK8SClient extends OharaTest with Matchers {
   private[this] def log(podName: String): SimpleServer = {
     val logMessage = "start pods ......."
     toServer {
-      path("namespaces" / "default" / "pods" / podName / "log") {
+      path("namespaces" / namespace / "pods" / podName / "log") {
         get {
           complete(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, logMessage)))
         }
@@ -590,7 +590,7 @@ class TestK8SClient extends OharaTest with Matchers {
           complete(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, nodesResponse)))
         }
       } ~
-        path("namespaces" / "default" / "pods") {
+        path("namespaces" / namespace / "pods") {
           post {
             entity(as[Pod]) { _ =>
               complete(
@@ -645,7 +645,7 @@ class TestK8SClient extends OharaTest with Matchers {
 
     // test communication
     toServer {
-      path("namespaces" / "default" / "pods") {
+      path("namespaces" / namespace / "pods") {
         get {
           complete(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, podsInfo)))
         }

--- a/ohara-configurator/src/main/scala/com/island/ohara/configurator/Configurator.scala
+++ b/ohara-configurator/src/main/scala/com/island/ohara/configurator/Configurator.scala
@@ -333,7 +333,7 @@ object Configurator {
         case Array(FOLDER_KEY, value)        => configuratorBuilder.homeFolder(value)
         case Array(HOSTNAME_KEY, value)      => configuratorBuilder.hostname(value)
         case Array(PORT_KEY, value)          => configuratorBuilder.port(value.toInt)
-        case Array(K8S_NAMESPACE_KEY, value) => configuratorBuilder.k8sNamespace(Option(value))
+        case Array(K8S_NAMESPACE_KEY, value) => configuratorBuilder.k8sNamespace(value)
         case Array(K8S_KEY, value)           => configuratorBuilder.k8sApiServer(value)
         case Array(FAKE_KEY, value) =>
           if (value.toBoolean) configuratorBuilder.fake()

--- a/ohara-configurator/src/main/scala/com/island/ohara/configurator/Configurator.scala
+++ b/ohara-configurator/src/main/scala/com/island/ohara/configurator/Configurator.scala
@@ -315,6 +315,7 @@ object Configurator {
   private[configurator] val HELP_KEY = "--help"
   private[configurator] val FOLDER_KEY = "--folder"
   private[configurator] val HOSTNAME_KEY = "--hostname"
+  private[configurator] val K8S_NAMESPACE_KEY = "--k8s-namespace"
   private[configurator] val K8S_KEY = "--k8s"
   private[configurator] val FAKE_KEY = "--fake"
   private[configurator] val PORT_KEY = "--port"
@@ -329,19 +330,11 @@ object Configurator {
     val configuratorBuilder = Configurator.builder
     try {
       args.sliding(2, 2).foreach {
-        case Array(FOLDER_KEY, value)   => configuratorBuilder.homeFolder(value)
-        case Array(HOSTNAME_KEY, value) => configuratorBuilder.hostname(value)
-        case Array(PORT_KEY, value)     => configuratorBuilder.port(value.toInt)
-        case Array(K8S_KEY, value) =>
-          import scala.concurrent.ExecutionContext.Implicits.global
-          val client = K8SClient(value, "default")
-          try if (Await.result(client.nodeNameIPInfo(), 30 seconds).isEmpty)
-            throw new IllegalArgumentException("your k8s clusters is empty!!!")
-          catch {
-            case e: Throwable =>
-              throw new IllegalArgumentException(s"unable to access k8s cluster:$value", e)
-          }
-          configuratorBuilder.k8sClient(client)
+        case Array(FOLDER_KEY, value)        => configuratorBuilder.homeFolder(value)
+        case Array(HOSTNAME_KEY, value)      => configuratorBuilder.hostname(value)
+        case Array(PORT_KEY, value)          => configuratorBuilder.port(value.toInt)
+        case Array(K8S_NAMESPACE_KEY, value) => configuratorBuilder.k8sNamespace(Option(value))
+        case Array(K8S_KEY, value)           => configuratorBuilder.k8sApiServer(value)
         case Array(FAKE_KEY, value) =>
           if (value.toBoolean) configuratorBuilder.fake()
         case _ =>

--- a/ohara-configurator/src/main/scala/com/island/ohara/configurator/Configurator.scala
+++ b/ohara-configurator/src/main/scala/com/island/ohara/configurator/Configurator.scala
@@ -334,7 +334,7 @@ object Configurator {
         case Array(PORT_KEY, value)     => configuratorBuilder.port(value.toInt)
         case Array(K8S_KEY, value) =>
           import scala.concurrent.ExecutionContext.Implicits.global
-          val client = K8SClient(value)
+          val client = K8SClient(value, "default")
           try if (Await.result(client.nodeNameIPInfo(), 30 seconds).isEmpty)
             throw new IllegalArgumentException("your k8s clusters is empty!!!")
           catch {

--- a/ohara-configurator/src/main/scala/com/island/ohara/configurator/ConfiguratorBuilder.scala
+++ b/ohara-configurator/src/main/scala/com/island/ohara/configurator/ConfiguratorBuilder.scala
@@ -46,7 +46,7 @@ class ConfiguratorBuilder private[configurator] extends Builder[Configurator] {
   private[this] var store: DataStore = _
   private[this] var serviceCollie: ServiceCollie = _
   private[this] var k8sClient: K8SClient = _
-  private[this] var k8sNamespace: Option[String] = None
+  private[this] var k8sNamespace: String = K8SClient.NAMESPACE_DEFAULT_VALUE
 
   @Optional("default is random folder")
   def homeFolder(homeFolder: String): ConfiguratorBuilder = doOrReleaseObjects {
@@ -391,7 +391,7 @@ class ConfiguratorBuilder private[configurator] extends Builder[Configurator] {
     * @return this builder
     */
   @Optional("default value is default")
-  private[configurator] def k8sNamespace(namespace: Option[String]): ConfiguratorBuilder = {
+  private[configurator] def k8sNamespace(namespace: String): ConfiguratorBuilder = {
     this.k8sNamespace = namespace
     this
   }

--- a/ohara-configurator/src/main/scala/com/island/ohara/configurator/ConfiguratorBuilder.scala
+++ b/ohara-configurator/src/main/scala/com/island/ohara/configurator/ConfiguratorBuilder.scala
@@ -46,6 +46,7 @@ class ConfiguratorBuilder private[configurator] extends Builder[Configurator] {
   private[this] var store: DataStore = _
   private[this] var serviceCollie: ServiceCollie = _
   private[this] var k8sClient: K8SClient = _
+  private[this] var k8sNamespace: Option[String] = None
 
   @Optional("default is random folder")
   def homeFolder(homeFolder: String): ConfiguratorBuilder = doOrReleaseObjects {
@@ -381,6 +382,36 @@ class ConfiguratorBuilder private[configurator] extends Builder[Configurator] {
     if (this.k8sClient != null) throw new IllegalArgumentException(alreadyExistMessage("k8sClient"))
     if (this.serviceCollie != null) throw new IllegalArgumentException(alreadyExistMessage("serviceCollie"))
     this.k8sClient = Objects.requireNonNull(k8sClient)
+    this
+  }
+
+  /**
+    * Set a k8s namespace to use k8s platform
+    * @param namespace k8s namespace
+    * @return this builder
+    */
+  @Optional("default value is default")
+  private[configurator] def k8sNamespace(namespace: Option[String]): ConfiguratorBuilder = {
+    this.k8sNamespace = namespace
+    this
+  }
+
+  /**
+    * Set a k8s api server url
+    * @param url k8s api server url
+    * @return this builder
+    */
+  @Optional("default value is null")
+  private[configurator] def k8sApiServer(url: String): ConfiguratorBuilder = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val client = K8SClient(url, k8sNamespace)
+    try if (Await.result(client.nodeNameIPInfo(), 30 seconds).isEmpty)
+      throw new IllegalArgumentException("your k8s clusters is empty!!!")
+    catch {
+      case e: Throwable =>
+        throw new IllegalArgumentException(s"unable to access k8s cluster:$url", e)
+    }
+    this.k8sClient(client)
     this
   }
 

--- a/ohara-configurator/src/test/scala/com/island/ohara/configurator/TestConfiguratorBuilder.scala
+++ b/ohara-configurator/src/test/scala/com/island/ohara/configurator/TestConfiguratorBuilder.scala
@@ -16,11 +16,17 @@
 
 package com.island.ohara.configurator
 
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Directives.{complete, get, path}
+import akka.http.scaladsl.{Http, server}
+import akka.stream.ActorMaterializer
 import com.island.ohara.agent.ServiceCollie
 import com.island.ohara.agent.k8s.K8SClient
 import com.island.ohara.client.configurator.v0.NodeApi.Node
 import com.island.ohara.common.rule.OharaTest
-import com.island.ohara.common.util.CommonUtils
+import com.island.ohara.common.util.{CommonUtils, Releasable}
 import org.junit.Test
 import org.scalatest.Matchers
 import org.scalatest.mockito.MockitoSugar
@@ -106,6 +112,57 @@ class TestConfiguratorBuilder extends OharaTest with Matchers {
     .build()
 
   @Test
+  def testK8SClientNamespaceDefault(): Unit = {
+    val namespace = "default"
+    val podName = "pod1"
+    val logMessage = "start pods ......."
+    val apiServer = k8sServer(namespace, podName, logMessage)
+    try {
+      val configurator: Configurator = Configurator.builder.k8sApiServer(apiServer.url).build()
+      Await.result(configurator.k8sClient.get.log(podName), 10 seconds) shouldBe logMessage
+
+    } finally apiServer.close()
+  }
+
+  @Test
+  def testK8SClientNamespaceAssign(): Unit = {
+    val namespace = Option("ohara")
+    val podName = "pod1"
+    val logMessage = "start pods ......."
+    val apiServer = k8sServer(namespace.get, podName, logMessage)
+    try {
+      val configurator: Configurator = Configurator.builder.k8sNamespace(namespace).k8sApiServer(apiServer.url).build()
+      Await.result(configurator.k8sClient.get.log(podName), 10 seconds) shouldBe logMessage
+
+    } finally apiServer.close()
+  }
+
+  @Test
+  def testK8SClientNamespaceNone(): Unit = {
+    val namespace = "default"
+    val podName = "pod1"
+    val logMessage = "start pods ......."
+    val apiServer = k8sServer(namespace, podName, logMessage)
+    try {
+      val configurator: Configurator = Configurator.builder.k8sClient(K8SClient(apiServer.url)).build()
+      Await.result(configurator.k8sClient.get.log(podName), 10 seconds) shouldBe logMessage
+    } finally apiServer.close()
+  }
+
+  @Test
+  def testK8SClientNamespace(): Unit = {
+    val namespace = "ohara"
+    val podName = "pod1"
+    val logMessage = "start pods ......."
+    val apiServer = k8sServer(namespace, podName, logMessage)
+    try {
+      val configurator: Configurator =
+        Configurator.builder.k8sClient(K8SClient(apiServer.url, Option(namespace))).build()
+      Await.result(configurator.k8sClient.get.log(podName), 10 seconds) shouldBe logMessage
+    } finally apiServer.close()
+  }
+
+  @Test
   def reassignServiceCollie(): Unit = an[IllegalArgumentException] should be thrownBy Configurator.builder
     .serviceCollie(MockitoSugar.mock[ServiceCollie])
     .serviceCollie(MockitoSugar.mock[ServiceCollie])
@@ -142,4 +199,83 @@ class TestConfiguratorBuilder extends OharaTest with Matchers {
     Configurator.builder
       .k8sClient(mock[K8SClient])
       .homeFolder(CommonUtils.createTempFolder(CommonUtils.randomString(5)).getAbsolutePath)
+
+  private[this] def toServer(route: server.Route): SimpleServer = {
+    implicit val system = ActorSystem("my-system")
+    implicit val materializer = ActorMaterializer()
+    val server = Await.result(Http().bindAndHandle(route, "localhost", 0), 30 seconds)
+
+    new SimpleServer {
+      override def hostname: String = server.localAddress.getHostString
+      override def port: Int = server.localAddress.getPort
+      override def close(): Unit = {
+        Await.result(server.unbind(), 30 seconds)
+        Await.result(system.terminate(), 30 seconds)
+      }
+    }
+  }
+
+  private[this] def k8sServer(namespace: String, podName: String, logMessage: String): SimpleServer = {
+    val podName = "pod1"
+    toServer {
+      path("namespaces" / namespace / "pods" / podName / "log") {
+        get {
+          complete(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, logMessage)))
+        }
+      } ~
+        path("nodes") {
+          get {
+            complete(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, k8sNodesResponse)))
+          }
+        }
+    }
+  }
+
+  private[this] val k8sNodesResponse = s"""
+        |{"items": [
+        |    {
+        |      "metadata": {
+        |        "name": "node1"
+        |      },
+        |      "status": {
+        |        "conditions": [
+        |          {
+        |            "type": "Ready",
+        |            "status": "True",
+        |            "lastHeartbeatTime": "2019-05-14T06:14:46Z",
+        |            "lastTransitionTime": "2019-04-15T08:21:11Z",
+        |            "reason": "KubeletReady",
+        |            "message": "kubelet is posting ready status"
+        |          }
+        |        ],
+        |        "addresses": [
+        |          {
+        |            "type": "InternalIP",
+        |            "address": "10.2.0.4"
+        |          },
+        |          {
+        |            "type": "Hostname",
+        |            "address": "ohara-it-02"
+        |          }
+        |        ],
+        |        "images": [
+        |          {
+        |            "names": [
+        |              "quay.io/coreos/etcd@sha256:ea49a3d44a50a50770bff84eab87bac2542c7171254c4d84c609b8c66aefc211",
+        |              "quay.io/coreos/etcd:v3.3.9"
+        |            ],
+        |            "sizeBytes": 39156721
+        |          }
+        |        ]
+        |      }
+        |    }
+        |  ]
+        |}""".stripMargin
+
+  trait SimpleServer extends Releasable {
+    def hostname: String
+    def port: Int
+
+    def url: String = s"http://$hostname:$port"
+  }
 }

--- a/ohara-configurator/src/test/scala/com/island/ohara/configurator/TestConfiguratorBuilder.scala
+++ b/ohara-configurator/src/test/scala/com/island/ohara/configurator/TestConfiguratorBuilder.scala
@@ -113,7 +113,7 @@ class TestConfiguratorBuilder extends OharaTest with Matchers {
 
   @Test
   def testK8SClientNamespaceDefault(): Unit = {
-    val namespace = "default"
+    val namespace = K8SClient.NAMESPACE_DEFAULT_VALUE
     val podName = "pod1"
     val logMessage = "start pods ......."
     val apiServer = k8sServer(namespace, podName, logMessage)
@@ -126,10 +126,10 @@ class TestConfiguratorBuilder extends OharaTest with Matchers {
 
   @Test
   def testK8SClientNamespaceAssign(): Unit = {
-    val namespace = Option("ohara")
+    val namespace = "ohara"
     val podName = "pod1"
     val logMessage = "start pods ......."
-    val apiServer = k8sServer(namespace.get, podName, logMessage)
+    val apiServer = k8sServer(namespace, podName, logMessage)
     try {
       val configurator: Configurator = Configurator.builder.k8sNamespace(namespace).k8sApiServer(apiServer.url).build()
       Await.result(configurator.k8sClient.get.log(podName), 10 seconds) shouldBe logMessage
@@ -139,7 +139,7 @@ class TestConfiguratorBuilder extends OharaTest with Matchers {
 
   @Test
   def testK8SClientNamespaceNone(): Unit = {
-    val namespace = "default"
+    val namespace = K8SClient.NAMESPACE_DEFAULT_VALUE
     val podName = "pod1"
     val logMessage = "start pods ......."
     val apiServer = k8sServer(namespace, podName, logMessage)
@@ -157,7 +157,7 @@ class TestConfiguratorBuilder extends OharaTest with Matchers {
     val apiServer = k8sServer(namespace, podName, logMessage)
     try {
       val configurator: Configurator =
-        Configurator.builder.k8sClient(K8SClient(apiServer.url, Option(namespace))).build()
+        Configurator.builder.k8sClient(K8SClient(apiServer.url, namespace)).build()
       Await.result(configurator.k8sClient.get.log(podName), 10 seconds) shouldBe logMessage
     } finally apiServer.close()
   }

--- a/ohara-it/build.gradle
+++ b/ohara-it/build.gradle
@@ -121,6 +121,7 @@ class OharaTest extends Test {
           // hostname used to expose the location of configurator
           "ohara.it.port",
           "ohara.it.k8s",
+          "ohara.it.k8s.namespace",
           "ohara.it.k8s.nodename",
           // set the prefix to all containers
           "ohara.it.container.prefix",

--- a/ohara-it/src/test/scala/com/island/ohara/it/EnvTestingUtils.scala
+++ b/ohara-it/src/test/scala/com/island/ohara/it/EnvTestingUtils.scala
@@ -29,7 +29,7 @@ object EnvTestingUtils {
 
   val K8S_MASTER_KEY: String = "ohara.it.k8s"
   private[this] val K8S_NODES_KEY: String = "ohara.it.k8s.nodename"
-
+  private[this] val K8S_NAMESPACE_KEY: String = "ohara.it.k8s.namespace"
   private[this] val CONFIGURATOR_HOSTNAME_KEY: String = "ohara.it.hostname"
   private[this] val CONFIGURATOR_HOSTPORT_KEY: String = "ohara.it.port"
 
@@ -43,7 +43,9 @@ object EnvTestingUtils {
     .toInt
 
   def k8sClient(): K8SClient = K8SClient(
-    sys.env.getOrElse(K8S_MASTER_KEY, throw new AssumptionViolatedException(s"$K8S_MASTER_KEY does not exists!!!")))
+    sys.env.getOrElse(K8S_MASTER_KEY, throw new AssumptionViolatedException(s"$K8S_MASTER_KEY does not exists!!!")),
+    sys.env.getOrElse(K8S_NAMESPACE_KEY, "default")
+  )
 
   def k8sNodes(): Seq[Node] = sys.env
     .get(K8S_NODES_KEY)

--- a/ohara-it/src/test/scala/com/island/ohara/it/EnvTestingUtils.scala
+++ b/ohara-it/src/test/scala/com/island/ohara/it/EnvTestingUtils.scala
@@ -44,7 +44,7 @@ object EnvTestingUtils {
 
   def k8sClient(): K8SClient = K8SClient(
     sys.env.getOrElse(K8S_MASTER_KEY, throw new AssumptionViolatedException(s"$K8S_MASTER_KEY does not exists!!!")),
-    sys.env.getOrElse(K8S_NAMESPACE_KEY, "default")
+    sys.env.get(K8S_NAMESPACE_KEY)
   )
 
   def k8sNodes(): Seq[Node] = sys.env

--- a/ohara-it/src/test/scala/com/island/ohara/it/EnvTestingUtils.scala
+++ b/ohara-it/src/test/scala/com/island/ohara/it/EnvTestingUtils.scala
@@ -44,7 +44,7 @@ object EnvTestingUtils {
 
   def k8sClient(): K8SClient = K8SClient(
     sys.env.getOrElse(K8S_MASTER_KEY, throw new AssumptionViolatedException(s"$K8S_MASTER_KEY does not exists!!!")),
-    sys.env.get(K8S_NAMESPACE_KEY)
+    sys.env.getOrElse(K8S_NAMESPACE_KEY, K8SClient.NAMESPACE_DEFAULT_VALUE)
   )
 
   def k8sNodes(): Seq[Node] = sys.env


### PR DESCRIPTION
### Checklist
- [x] [Review Contribution Guidelines](https://ohara.readthedocs.io/en/latest/contributing.html)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#ohara-team))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #3150 )
- [x] Add unit tests (or please explain why this PR is not worth having new tests)
- [ ] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)