### PR TITLE
#3372 The loop of updating k8s nodes swallow all resources of thread pool

### DIFF
--- a/ohara-configurator/src/main/scala/com/island/ohara/configurator/Configurator.scala
+++ b/ohara-configurator/src/main/scala/com/island/ohara/configurator/Configurator.scala
@@ -16,7 +16,7 @@
 
 package com.island.ohara.configurator
 
-import java.util.concurrent.{ExecutionException, Executors, ScheduledExecutorService, TimeUnit}
+import java.util.concurrent.{ExecutionException, Executors, TimeUnit}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -66,8 +66,8 @@ class Configurator private[configurator] (val hostname: String, val port: Int)(
     value
   }
 
-  private[this] val threadPool                                 = Executors.newFixedThreadPool(threadMax)
-  private[this] var checkK8SNodePool: ScheduledExecutorService = _
+  private[this] val threadPool       = Executors.newFixedThreadPool(threadMax)
+  private[this] val checkK8SNodePool = Executors.newSingleThreadExecutor()
 
   private[this] implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(threadPool)
 
@@ -189,42 +189,36 @@ class Configurator private[configurator] (val hostname: String, val port: Int)(
   }
 
   private[configurator] def executeAddK8SNodes[T](timeout: Long): Unit = {
-    checkK8SNodePool = Executors.newSingleThreadScheduledExecutor()
-    val ckeckNodeExecutionContext: ExecutionContext = ExecutionContext.fromExecutorService(checkK8SNodePool)
-    checkK8SNodePool.scheduleWithFixedDelay(
-      loopRunning(addK8SNodes(ckeckNodeExecutionContext), timeout),
-      0,
-      timeout,
-      TimeUnit.SECONDS
-    )
-    if (checkK8SNodePool.awaitTermination(terminateTimeout.toMillis, TimeUnit.MILLISECONDS))
-      log.info("Terminate the check kubernetes new node.")
+    checkK8SNodePool.execute(loopRunning(addK8SNodes(), timeout))
   }
 
-  private[configurator] def addK8SNodes(ckeckNodeExecutionContext: ExecutionContext): Future[Seq[NodeApi.Node]] = {
+  private[configurator] def addK8SNodes(): Future[Seq[NodeApi.Node]] = {
     log.info("Running check Kubernetes node")
     val nodeApi           = NodeApi.access.hostname(hostname).port(port)
     val client: K8SClient = this.k8sClient.getOrElse(throw new RuntimeException("K8SClient object isn't exist"))
     client
-      .nodes()(ckeckNodeExecutionContext)
+      .nodes()
       .flatMap(
         nodes =>
           Future.sequence(nodes.map { k8sNode =>
             nodeApi
-              .list()(ckeckNodeExecutionContext)
+              .list()
               .map(
                 nodes =>
                   if (nodes.map(_.hostname).contains(k8sNode.nodeName)) Seq.empty
-                  else Seq(nodeApi.request.hostname(k8sNode.nodeName).create()(ckeckNodeExecutionContext))
-              )(ckeckNodeExecutionContext)
-          })(implicitly, ckeckNodeExecutionContext)
-      )(ckeckNodeExecutionContext)
-      .flatMap(x => Future.sequence(x.flatten)(implicitly, ckeckNodeExecutionContext))(ckeckNodeExecutionContext)
+                  else Seq(nodeApi.request.hostname(k8sNode.nodeName).create())
+              )
+          })
+      )
+      .flatMap(x => Future.sequence(x.flatten))
   }
 
   private[this] def loopRunning(future: => Unit, timeout: Long): Runnable = new Runnable() {
     def run(): Unit = {
-      future
+      while (true) {
+        TimeUnit.SECONDS.sleep(timeout)
+        future
+      }
     }
   }
 

--- a/ohara-configurator/src/test/scala/com/island/ohara/configurator/TestConfigurator.scala
+++ b/ohara-configurator/src/test/scala/com/island/ohara/configurator/TestConfigurator.scala
@@ -16,15 +16,12 @@
 
 package com.island.ohara.configurator
 
-import java.util.concurrent.Executors
-
 import com.island.ohara.agent.fake.FakeK8SClient
 import com.island.ohara.agent.k8s.K8SNodeReport
 import com.island.ohara.client.configurator.v0.NodeApi
 import com.island.ohara.common.rule.OharaTest
 import org.junit.Test
 import org.scalatest.Matchers._
-
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -42,9 +39,7 @@ class TestConfigurator extends OharaTest {
     val createNode = Await.result(nodeApi.request.hostname("node1").create(), 15 seconds)
     createNode.hostname shouldBe "node1"
 
-    val checkK8SNodePool                            = Executors.newFixedThreadPool(1)
-    val ckeckNodeExecutionContext: ExecutionContext = ExecutionContext.fromExecutorService(checkK8SNodePool)
-    val nodes                                       = Await.result(configurator.addK8SNodes(ckeckNodeExecutionContext), 15 seconds)
+    val nodes = Await.result(configurator.addK8SNodes(), 15 seconds)
     nodes.size shouldBe 2
     nodes(0).hostname shouldBe "node2"
     nodes(1).hostname shouldBe "node3"

--- a/ohara-configurator/src/test/scala/com/island/ohara/configurator/TestConfigurator.scala
+++ b/ohara-configurator/src/test/scala/com/island/ohara/configurator/TestConfigurator.scala
@@ -16,12 +16,15 @@
 
 package com.island.ohara.configurator
 
+import java.util.concurrent.Executors
+
 import com.island.ohara.agent.fake.FakeK8SClient
 import com.island.ohara.agent.k8s.K8SNodeReport
 import com.island.ohara.client.configurator.v0.NodeApi
 import com.island.ohara.common.rule.OharaTest
 import org.junit.Test
 import org.scalatest.Matchers._
+
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -39,7 +42,9 @@ class TestConfigurator extends OharaTest {
     val createNode = Await.result(nodeApi.request.hostname("node1").create(), 15 seconds)
     createNode.hostname shouldBe "node1"
 
-    val nodes = Await.result(configurator.addK8SNodes(), 15 seconds)
+    val checkK8SNodePool                            = Executors.newFixedThreadPool(1)
+    val ckeckNodeExecutionContext: ExecutionContext = ExecutionContext.fromExecutorService(checkK8SNodePool)
+    val nodes                                       = Await.result(configurator.addK8SNodes(ckeckNodeExecutionContext), 15 seconds)
     nodes.size shouldBe 2
     nodes(0).hostname shouldBe "node2"
     nodes(1).hostname shouldBe "node3"


### PR DESCRIPTION
### Checklist
- [x] [Review Contribution Guidelines](https://ohara.readthedocs.io/en/latest/contributing.html)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#ohara-team))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #3372 )
- [ ] Add unit tests (or please explain why this PR is not worth having new tests)
- [ ] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)