### PR TITLE
#3439 Increase sleep seconds for the TestQueryConfiguratorLog test

### DIFF
--- a/ohara-it/src/test/scala/com/island/ohara/it/client/TestQueryConfiguratorLog.scala
+++ b/ohara-it/src/test/scala/com/island/ohara/it/client/TestQueryConfiguratorLog.scala
@@ -38,10 +38,10 @@ class TestQueryConfiguratorLog extends WithRemoteConfigurator {
     log.logs.head.value.length should not be 0
 
     val logOf1Second = result(LogApi.access.hostname(configuratorHostname).port(configuratorPort).log4Configurator(1)).logs.head.value
-    TimeUnit.SECONDS.sleep(3)
-    val logOf3Second = result(LogApi.access.hostname(configuratorHostname).port(configuratorPort).log4Configurator(3)).logs.head.value
-    withClue(s"logOf1Second:$logOf1Second\nlogOf3Second:$logOf3Second") {
-      logOf1Second.length should be < logOf3Second.length
+    TimeUnit.SECONDS.sleep(6)
+    val logOf6Second = result(LogApi.access.hostname(configuratorHostname).port(configuratorPort).log4Configurator(6)).logs.head.value
+    withClue(s"logOf1Second:$logOf1Second\nlogOf6Second:$logOf6Second") {
+      logOf1Second.length should be < logOf6Second.length
     }
   }
 }


### PR DESCRIPTION
### Checklist
- [x] [Review Contribution Guidelines](https://ohara.readthedocs.io/en/latest/contributing.html)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#ohara-team))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #3439 )
- [ ] Add unit tests (or please explain why this PR is not worth having new tests)
- [ ] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)