### PR TITLE
#3125 Modify the JDBC preparedstatement to a global variable to avoid opening many statements

### DIFF
--- a/ohara-connector/src/main/scala/com/island/ohara/connector/jdbc/source/JDBCSourceTask.scala
+++ b/ohara-connector/src/main/scala/com/island/ohara/connector/jdbc/source/JDBCSourceTask.scala
@@ -72,7 +72,7 @@ class JDBCSourceTask extends RowSourceTask {
         var topicOffset                 = topicOffsets.readOffset()
         val resultSet: QueryResultIterator =
           dbTableDataProvider
-            .executeQuery(tableName, timestampColumnName, Timestamp.valueOf(parseOffsetInfo(inMemoryOffset).timestamp))
+            .executeQuery(Timestamp.valueOf(parseOffsetInfo(inMemoryOffset).timestamp))
 
         var recoveryQueryRecordCount = parseOffsetInfo(topicOffset).queryRecordCount
 

--- a/ohara-connector/src/test/scala/com/island/ohara/connector/jdbc/source/TestDBTableDataProvider.scala
+++ b/ohara-connector/src/test/scala/com/island/ohara/connector/jdbc/source/TestDBTableDataProvider.scala
@@ -32,13 +32,13 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
 class TestDBTableDataProvider extends OharaTest {
-  private[this] val db        = Database.local()
-  private[this] val client    = DatabaseClient.builder.url(db.url()).user(db.user()).password(db.password()).build
-  private[this] val tableName = "table1"
-
+  private[this] val db                  = Database.local()
+  private[this] val client              = DatabaseClient.builder.url(db.url()).user(db.user()).password(db.password()).build
+  private[this] val tableName           = "table1"
+  private[this] val timestampColumnName = "column1"
   @Before
   def setup(): Unit = {
-    val column1 = RdbColumn("column1", "TIMESTAMP(6)", true)
+    val column1 = RdbColumn(timestampColumnName, "TIMESTAMP(6)", true)
     val column2 = RdbColumn("column2", "varchar(45)", false)
     val column3 = RdbColumn("column3", "VARCHAR(45)", false)
     val column4 = RdbColumn("column4", "integer", false)
@@ -47,26 +47,26 @@ class TestDBTableDataProvider extends OharaTest {
     val statement: Statement = db.connection.createStatement()
 
     statement.executeUpdate(
-      s"INSERT INTO $tableName(column1,column2,column3,column4) VALUES('2018-09-01 00:00:00', 'a11', 'a12', 1)"
+      s"INSERT INTO $tableName($timestampColumnName,column2,column3,column4) VALUES('2018-09-01 00:00:00', 'a11', 'a12', 1)"
     )
     statement.executeUpdate(
-      s"INSERT INTO $tableName(column1,column2,column3,column4) VALUES('2018-09-01 00:00:01', 'a21', 'a22', 2)"
+      s"INSERT INTO $tableName($timestampColumnName,column2,column3,column4) VALUES('2018-09-01 00:00:01', 'a21', 'a22', 2)"
     )
     statement.executeUpdate(
-      s"INSERT INTO $tableName(column1,column2,column3,column4) VALUES('2018-09-01 00:00:02', 'a31', 'a32', 3)"
+      s"INSERT INTO $tableName($timestampColumnName,column2,column3,column4) VALUES('2018-09-01 00:00:02', 'a31', 'a32', 3)"
     )
     statement.executeUpdate(
-      s"INSERT INTO $tableName(column1,column2,column3,column4) VALUES(NOW() + INTERVAL 3 MINUTE, 'a41', 'a42', 4)"
+      s"INSERT INTO $tableName($timestampColumnName,column2,column3,column4) VALUES(NOW() + INTERVAL 3 MINUTE, 'a41', 'a42', 4)"
     )
     statement.executeUpdate(
-      s"INSERT INTO $tableName(column1,column2,column3,column4) VALUES(NOW() + INTERVAL 1 DAY, 'a51', 'a52', 5)"
+      s"INSERT INTO $tableName($timestampColumnName,column2,column3,column4) VALUES(NOW() + INTERVAL 1 DAY, 'a51', 'a52', 5)"
     )
   }
 
   @Test
   def testRowListResultSet(): Unit = {
     val dbTableDataProvider          = new DBTableDataProvider(jdbcConfig)
-    val results: QueryResultIterator = dbTableDataProvider.executeQuery(tableName, "column1", new Timestamp(0)) //0 is 1970-01-01 00:00:00
+    val results: QueryResultIterator = dbTableDataProvider.executeQuery(new Timestamp(0)) //0 is 1970-01-01 00:00:00
 
     var count                                      = 0
     val resultList: ListBuffer[Seq[ColumnInfo[_]]] = new ListBuffer[Seq[ColumnInfo[_]]]
@@ -94,7 +94,7 @@ class TestDBTableDataProvider extends OharaTest {
   def testColumnList(): Unit = {
     val dbTableDataProvider = new DBTableDataProvider(jdbcConfig)
     val columns             = dbTableDataProvider.columns(tableName)
-    columns.head.name shouldBe "column1"
+    columns.head.name shouldBe timestampColumnName
     columns(1).name shouldBe "column2"
     columns(2).name shouldBe "column3"
     columns(3).name shouldBe "column4"
@@ -115,14 +115,14 @@ class TestDBTableDataProvider extends OharaTest {
   @Test
   def testQueryFlag(): Unit = {
     val dbTableDataProvider = new DBTableDataProvider(jdbcConfig)
-    val result1             = dbTableDataProvider.executeQuery(tableName, "column1", new Timestamp(0))
+    val result1             = dbTableDataProvider.executeQuery(new Timestamp(0))
     result1.size shouldBe 3
 
-    val result2 = dbTableDataProvider.executeQuery(tableName, "column1", new Timestamp(0))
+    val result2 = dbTableDataProvider.executeQuery(new Timestamp(0))
     result2.size shouldBe 0
 
     dbTableDataProvider.releaseResultSet(true)
-    val result3 = dbTableDataProvider.executeQuery(tableName, "column1", new Timestamp(0))
+    val result3 = dbTableDataProvider.executeQuery(new Timestamp(0))
     result3.size shouldBe 3
   }
 
@@ -140,7 +140,7 @@ class TestDBTableDataProvider extends OharaTest {
         DB_PASSWORD           -> db.password,
         DB_TABLENAME          -> tableName,
         DB_SCHEMA_PATTERN     -> "schema1",
-        TIMESTAMP_COLUMN_NAME -> "CDC_TIMESTAMP"
+        TIMESTAMP_COLUMN_NAME -> timestampColumnName
       )
     JDBCSourceConnectorConfig(TaskSetting.of(map.asJava))
   }


### PR DESCRIPTION
### Checklist
- [x] [Review Contribution Guidelines](https://ohara.readthedocs.io/en/latest/contributing.html)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#ohara-team))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #3125 )
- [ ] Add unit tests (or please explain why this PR is not worth having new tests)
- [ ] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)