### PR TITLE
#3665 Before start the connector, await worker http server completed for performance test

### DIFF
--- a/ohara-it/src/test/scala/com/island/ohara/it/performance/BasicTestPerformance.scala
+++ b/ohara-it/src/test/scala/com/island/ohara/it/performance/BasicTestPerformance.scala
@@ -137,18 +137,20 @@ abstract class BasicTestPerformance extends WithRemoteWorkers {
     className: String,
     settings: Map[String, JsValue]
   ): ConnectorInfo = {
-    result(
-      connectorApi.request
-        .settings(settings)
-        .key(connectorKey)
-        .className(className)
-        .topicKey(topicKey)
-        .workerClusterKey(workerClusterInfo.key)
-        .numberOfTasks(numberOfConnectorTasks)
-        .create()
-    )
+    //Before create and start the connector, need to await
+    // worker http server running completed.
     await(
       () => {
+        result(
+          connectorApi.request
+            .settings(settings)
+            .key(connectorKey)
+            .className(className)
+            .topicKey(topicKey)
+            .workerClusterKey(workerClusterInfo.key)
+            .numberOfTasks(numberOfConnectorTasks)
+            .create()
+        )
         result(connectorApi.start(connectorKey))
         true
       },


### PR DESCRIPTION
### Checklist
- [x] [Review Contribution Guidelines](https://ohara.readthedocs.io/en/latest/contributing.html)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#ohara-team))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #3665 )
- [ ] Add unit tests (or please explain why this PR is not worth having new tests)
- [x] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)