### PR TITLE
#4793 Fix flaky TestJDBCSourceConnectorExactlyOnce

### DIFF
--- a/ohara-connector/src/test/scala/oharastream/ohara/connector/jdbc/source/TestJDBCSourceConnectorExactlyOnce.scala
+++ b/ohara-connector/src/test/scala/oharastream/ohara/connector/jdbc/source/TestJDBCSourceConnectorExactlyOnce.scala
@@ -261,8 +261,9 @@ class TestJDBCSourceConnectorExactlyOnce(inputDataTime: Long) extends With3Broke
       TimeUnit.SECONDS.sleep(3)
       statement.executeUpdate(s"UPDATE $tableName SET $timestampColumnName=NOW() WHERE $queryColumn='hello'")
 
-      val result = consumer.poll(java.time.Duration.ofSeconds(30), tableTotalCount.intValue()).asScala
-      result.size shouldBe tableTotalCount.intValue() + 2 // Because update and insert the different timestamp
+      val expectedRow = tableTotalCount.intValue() + 2
+      val result      = consumer.poll(java.time.Duration.ofSeconds(30), expectedRow).asScala
+      result.size shouldBe expectedRow // Because update and insert the different timestamp
     } finally {
       result(connectorAdmin.delete(connectorKey)) // Avoid table not forund from the JDBC source connector
       Releasable.close(statement)


### PR DESCRIPTION
### Checklist
- [x] [Review Contribution Guidelines](https://ohara.readthedocs.io/en/latest/contributing.html)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#ohara-team))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #4793)
- [ ] Add unit tests (or please explain why this PR is not worth having new tests)
- [ ] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)