### PR TITLE
#5274 fix flaky RemoteFolderHandler#exist catch exception message 

### DIFF
--- a/ohara-agent/src/main/scala/oharastream/ohara/agent/Agent.scala
+++ b/ohara-agent/src/main/scala/oharastream/ohara/agent/Agent.scala
@@ -113,7 +113,7 @@ object Agent {
 
     /**
       * set remote's ssh connection timeout
-      * @param password ssh password
+      * @param timeout ssh timeout duration
       * @return this builder
       */
     def timeout(timeout: Duration): Builder = {

--- a/ohara-agent/src/main/scala/oharastream/ohara/agent/RemoteFolderHandler.scala
+++ b/ohara-agent/src/main/scala/oharastream/ohara/agent/RemoteFolderHandler.scala
@@ -86,11 +86,11 @@ object RemoteFolderHandler {
         // it returns the "path" if the "path" is a file
         try !agent
         // export LANG=en_US.UTF-8: The return message is always english.
-          .execute(s"export LANG=en_US.UTF-8;ls $path")
+          .execute(s"ls $path")
           .map(_.trim)
           .contains(path)
         catch {
-          case e: Throwable if e.getMessage.contains("No such file or directory") => false
+          case e: Throwable if e.getMessage.contains(path) => false
         }
 
       override def exist(hostname: String, path: String)(

--- a/ohara-agent/src/main/scala/oharastream/ohara/agent/RemoteFolderHandler.scala
+++ b/ohara-agent/src/main/scala/oharastream/ohara/agent/RemoteFolderHandler.scala
@@ -85,7 +85,8 @@ object RemoteFolderHandler {
       private[this] def exist(agent: Agent, path: String): Boolean =
         // it returns the "path" if the "path" is a file
         try !agent
-          .execute(s"ls $path")
+        // export LANG=en_US.UTF-8: The return message is always english.
+          .execute(s"export LANG=en_US.UTF-8;ls $path")
           .map(_.trim)
           .contains(path)
         catch {


### PR DESCRIPTION
### Checklist
- [x] [Review Contribution Guidelines](https://ohara.readthedocs.io/en/latest/contributing.html)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#ohara-team))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #5274 )
- [ ] Add unit tests (or please explain why this PR is not worth having new tests)
- [ ] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)