### PR TITLE
#5725 [Manager] Initialize the value of the usedBy field in the create volume dialog

### DIFF
--- a/ohara-manager/client/src/components/Volume/VolumeCreateDialog.js
+++ b/ohara-manager/client/src/components/Volume/VolumeCreateDialog.js
@@ -71,6 +71,13 @@ const VolumeCreateDialog = ({
     }
   };
 
+  const change = hooks.useReduxFormChangeAction();
+
+  // Initialize the value of the "usedBy" field
+  React.useEffect(() => {
+    change(Form.CREATE_VOLUME, 'usedBy', usedBy);
+  }, [change, usedBy]);
+
   return (
     <Dialog
       confirmDisabled={


### PR DESCRIPTION
### Checklist
- [x] [Review Contribution Guidelines](https://github.com/oharastream/ohara/blob/master/CONTRIBUTING.md)
- [x] Add Reviewers (see [Authors](https://github.com/oharastream/ohara#authors))
- [x] Add Assignees (of course, you are the assignee by default!)
- [x] DON'T set a Milestone
- [x] DON'T add any labels (PR labels will be added automatically by Jenkins)
- [x] Link to an issue(You can do so by using the required by keyword: required by #5725 )
- [ ] Add unit tests (or please explain why this PR is not worth having new tests)
- [ ] Pass QA (Sometimes you may encounter an existing flaky test which would obstruct you from getting QA passed. If the failed tests are unrelated, you can add a comment in the PR thread)